### PR TITLE
Remove outdated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,10 +11,7 @@
   "noarg": true,
   "undef": true,
   "strict": false,
-  "trailing": true,
-  "smarttabs": true,
   "indent": 2,
-  "white": true,
   "quotmark": "single",
   "laxbreak": true
 }


### PR DESCRIPTION
Since JSHint v2.5 the `trailing`, `smarttabs` and `white` options are removed https://github.com/jshint/jshint/releases/tag/2.5.0
