### PR TITLE
Add --silent to npm root -g to avoid error when loglevel is above warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,16 @@ var doctor = module.exports = {
     }
 
     var nodePaths = process.env.NODE_PATH.split(path.delimiter).map(path.normalize);
-    var npmRoot = shell.exec('npm -g root --silent', { silent: true }).output;
+    var npmCmd = shell.exec('npm -g root --silent', { silent: true });
+    var exitcode = npmCmd.code;
+
+    if (exitcode !== 0) {
+        console.log(chalk.red('[Yeoman Doctor] Impossible to find the npm root, something went wrong.'));
+        console.log(chalk.cyan('Try to execute ') + chalk.green('npm -g root --silent') + chalk.cyan(' on your command line'));
+        process.exit(exitcode);
+    }
+
+    var npmRoot = npmCmd.output;
 
     npmRoot = path.normalize(npmRoot.trim());
 


### PR DESCRIPTION
I have had problems when installing yo and this is due to the fact that yodoctor will run 

```
npm -g root
```

without checking if the loglevel is above warn. So in my case, loglevel is always at _info_, and this creates unnecessary errors.

```
[Yeoman Doctor] Uh oh, I found potential errors on your machine
---------------

[Error] npm root value is not in your NODE_PATH
  [info]
    NODE_PATH = /home/jelte/.nvm/v0.10.33/lib/node_modules
    npm root  = npm info it worked if it ends with ok
npm info using npm@2.1.9
npm info using node@v0.10.33
/home/j3lte/.nvm/v0.10.33/lib/node_modules
npm info ok

  [Fix] Append the npm root value to your NODE_PATH variable
    Add this line to your .bashrc
      export NODE_PATH=$NODE_PATH:npm info it worked if it ends with ok
npm info using npm@2.1.9
npm info using node@v0.10.33
/home/j3lte/.nvm/v0.10.33/lib/node_modules
npm info ok
    Or run this command
      echo "export NODE_PATH=$NODE_PATH:npm info it worked if it ends with ok
npm info using npm@2.1.9
npm info using node@v0.10.33
/home/j3lte/.nvm/v0.10.33/lib/node_modules
npm info ok" >> ~/.bashrc && source ~/.bashrc
```

In order to circumvent this, I propose adding the --silent argument to this argument.
