### PR TITLE
Ensure recent Node.js and npm version

### DIFF
--- a/lib/messages/node-version.twig
+++ b/lib/messages/node-version.twig
@@ -1,0 +1,3 @@
+
+{{ 'Your Node.js version is outdated.' | red }}
+Upgrade to the latest version: {{ 'https://nodejs.org' | blue | underline }}

--- a/lib/messages/npm-version.twig
+++ b/lib/messages/npm-version.twig
@@ -1,0 +1,10 @@
+
+{{ 'Your npm version is outdated.' | red }}
+
+Upgrade to the latest version by running:
+{{ 'npm install -g npm' | magenta }}
+{% if isWin %}
+
+See this guide if you're having trouble upgrading:
+{{ 'https://github.com/npm/npm/wiki/Troubleshooting#upgrading-on-windows' | blue | underline }}
+{% endif %}

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -4,3 +4,4 @@ exports['global_config'] = require('./global_config');
 exports['node_path'] = require('./node_path');
 exports['yo-rc-home'] = require('./yo-rc-home');
 exports['node-version'] = require('./node-version');
+exports['npm-version'] = require('./npm-version');

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -3,3 +3,4 @@ exports['bowerrc-home'] = require('./bowerrc-home');
 exports['global_config'] = require('./global_config');
 exports['node_path'] = require('./node_path');
 exports['yo-rc-home'] = require('./yo-rc-home');
+exports['node-version'] = require('./node-version');

--- a/lib/rules/node-version.js
+++ b/lib/rules/node-version.js
@@ -1,0 +1,17 @@
+'use strict';
+var semver = require('semver');
+var message = require('../message');
+
+var OLDEST_NODE_VERSION = '0.12.0';
+
+exports.description = 'Node.js version';
+
+var errors = exports.errors = {
+  oldNodeVersion: function () {
+    return message.get('node-version');
+  }
+};
+
+exports.verify = function (cb) {
+  cb(semver.lt(process.version, OLDEST_NODE_VERSION) ? errors.oldNodeVersion() : null);
+};

--- a/lib/rules/npm-version.js
+++ b/lib/rules/npm-version.js
@@ -1,0 +1,21 @@
+'use strict';
+var binVersionCheck = require('bin-version-check');
+var message = require('../message');
+
+exports.OLDEST_NPM_VERSION = '2.9.0';
+
+exports.description = 'npm version';
+
+var errors = exports.errors = {
+  oldNpmVersion: function () {
+    return message.get('npm-version', {
+      isWin: process.platform === 'win32'
+    });
+  }
+};
+
+exports.verify = function (cb) {
+  binVersionCheck('npm', '>=' + exports.OLDEST_NPM_VERSION, function (err) {
+    cb(err ? errors.oldNpmVersion() : null);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check"
   ],
   "dependencies": {
+    "bin-version-check": "^2.1.0",
     "chalk": "^1.0.0",
     "each-async": "^1.1.1",
     "log-symbols": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "each-async": "^1.1.1",
     "log-symbols": "^1.0.1",
     "object-values": "^1.0.0",
+    "semver": "^4.3.6",
     "twig": "^0.8.2",
     "user-home": "^1.1.0"
   },

--- a/test/rule-node-version.js
+++ b/test/rule-node-version.js
@@ -1,0 +1,33 @@
+'use strict';
+var assert = require('assert');
+var rule = require('../lib/rules/node-version');
+var _processVersion;
+
+before(function () {
+  _processVersion = process.version;
+  Object.defineProperty(process, 'version', {writable: true});
+});
+
+after(function () {
+  process.version = _processVersion;
+});
+
+describe('Node.js version', function () {
+  it('pass if it\'s new enough', function (cb) {
+    process.version = 'v100.0.0';
+
+    rule.verify(function (err) {
+      assert(!err, err);
+      cb();
+    });
+  });
+
+  it('fail if it\'s too old', function (cb) {
+    process.version = 'v0.10.0';
+
+    rule.verify(function (err) {
+      assert(err, err);
+      cb();
+    });
+  });
+});

--- a/test/rule-npm-version.js
+++ b/test/rule-npm-version.js
@@ -1,0 +1,23 @@
+'use strict';
+var assert = require('assert');
+var rule = require('../lib/rules/npm-version');
+
+describe('npm version', function () {
+  it('pass if it\'s new enough', function (cb) {
+    rule.OLDEST_NPM_VERSION = 'v1.0.0';
+
+    rule.verify(function (err) {
+      assert(!err, err);
+      cb();
+    });
+  });
+
+  it('fail if it\'s too old', function (cb) {
+    rule.OLDEST_NPM_VERSION = 'v100.0.0';
+
+    rule.verify(function (err) {
+      assert(err, err);
+      cb();
+    });
+  });
+});


### PR DESCRIPTION
Added checks to make sure the user is running on a recent Node.js and npm version. A big amount of the issues we get are related to outdated Node.js and npm versions, so I think this can help bring that down.

![screen shot 2015-06-05 at 18 29 59](https://cloud.githubusercontent.com/assets/170270/8010511/06fe640c-0bb1-11e5-9c03-d4d125e4f445.png)


-

This module is run everytime someone installs [`yo`](https://www.npmjs.com/package/yo), which currently has almost 30.000 downloads a week. Getting more people on recent Node.js and npm versions will benefit the whole ecosystem greatly.

-

// @SBoudrias @addyosmani 

-

@othiym23 @zkat Fyi, and let me know if you have any improvement suggestions to the npm message ;)