### PR TITLE
fix windows bug on npm version check

### DIFF
--- a/lib/rules/npm-version.js
+++ b/lib/rules/npm-version.js
@@ -15,7 +15,7 @@ var errors = exports.errors = {
 };
 
 exports.verify = function (cb) {
-  binVersionCheck('npm', '>=' + exports.OLDEST_NPM_VERSION, function (err) {
+  binVersionCheck(process.platform === 'win32' ? 'npm.cmd' : 'npm', '>=' + exports.OLDEST_NPM_VERSION, function (err) {
     cb(err ? errors.oldNpmVersion() : null);
   });
 };


### PR DESCRIPTION
npm version check on windows shall use 'npm.cmd' as argument and not
only 'npm' when calling binVersionCheck function