### PR TITLE
Follow symbolic links if it exists

### DIFF
--- a/lib/rules/node_path.js
+++ b/lib/rules/node_path.js
@@ -1,4 +1,5 @@
 'use strict';
+var fs = require('fs');
 var path = require('path');
 var childProcess = require('child_process');
 var message = require('../message');
@@ -25,7 +26,17 @@ var errors = exports.errors = {
 };
 
 function fixPath(filepath) {
-  return path.resolve(path.normalize(filepath.trim()));
+  var fixedPath = path.resolve(path.normalize(filepath.trim()));
+
+  try {
+    fixedPath = fs.realpathSync(fixedPath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+
+  return fixedPath;
 }
 
 exports.verify = function (cb) {


### PR DESCRIPTION
In the case of symlinks, NODE_PATH does not match the npm root.