### PR TITLE
Add yo version checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ node_js:
 before_script:
   - npm link
   - yodoctor
+before_install:
+  - npm install -g yo@latest

--- a/lib/messages/yo-version-out-of-date.twig
+++ b/lib/messages/yo-version-out-of-date.twig
@@ -1,0 +1,5 @@
+
+{{ 'Your yo version is outdated.' | red }}
+
+Upgrade to the latest version by running:
+{{ 'npm install -g yo@latest' | magenta }}

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -6,3 +6,4 @@ exports['node_path'] = require('./node_path');
 exports['yo-rc-home'] = require('./yo-rc-home');
 exports['node-version'] = require('./node-version');
 exports['npm-version'] = require('./npm-version');
+exports['yo-version'] = require('./yo-version');

--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -1,7 +1,7 @@
 'use strict';
-var message = require('../message');
 var latestVersion = require('latest-version');
 var binVersionCheck = require('bin-version-check');
+var message = require('../message');
 
 exports.description = 'yo version';
 

--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -16,10 +16,7 @@ exports.verify = function (cb) {
     console.error(err);
     cb(err);
   }).then(function (version) {
-    if (typeof exports.OLDEST_YO_VERSION === 'undefined') {
-      exports.OLDEST_YO_VERSION = version;
-    }
-    binVersionCheck('yo', '>=' + exports.OLDEST_YO_VERSION, function (err) {
+    binVersionCheck('yo', '>=' + version, function (err) {
       cb(err ? errors.oldYoVersion() : null);
     });
   });

--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -1,0 +1,26 @@
+'use strict';
+var message = require('../message');
+var latestVersion = require('latest-version');
+var binVersionCheck = require('bin-version-check');
+
+exports.description = 'yo version';
+
+var errors = exports.errors = {
+  oldYoVersion: function () {
+    return message.get('yo-version-out-of-date', {});
+  }
+};
+
+exports.verify = function (cb) {
+  latestVersion('yo').catch(function (err) {
+    console.error(err);
+    cb(err);
+  }).then(function (version) {
+    if (typeof exports.OLDEST_YO_VERSION === 'undefined') {
+      exports.OLDEST_YO_VERSION = version;
+    }
+    binVersionCheck('yo', '>=' + exports.OLDEST_YO_VERSION, function (err) {
+      cb(err ? errors.oldYoVersion() : null);
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chalk": "^1.0.0",
     "each-async": "^1.1.1",
     "log-symbols": "^1.0.1",
+    "latest-version": "^2.0.0",
     "object-values": "^1.0.0",
     "semver": "^5.0.3",
     "twig": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "mocha": "^2.0.1",
+    "proxyquire": "^1.7.9",
     "sinon": "^1.12.1",
     "xo": "*"
   },

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -1,6 +1,5 @@
 'use strict';
 var assert = require('assert');
-var rule = require('../lib/rules/yo-version');
 var proxyquire = require('proxyquire');
 
 describe('yo version', function () {

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -1,0 +1,23 @@
+'use strict';
+var assert = require('assert');
+var rule = require('../lib/rules/yo-version');
+
+describe('yo version', function () {
+  it('pass if it\'s new enough', function (cb) {
+    rule.OLDEST_YO_VERSION = 'v0.0.0';
+
+    rule.verify(function (err) {
+      assert(!err, err);
+      cb();
+    });
+  });
+
+  it('fail if it\'s too old', function (cb) {
+    rule.OLDEST_YO_VERSION = 'v100.0.0';
+
+    rule.verify(function (err) {
+      assert(err, err);
+      cb();
+    });
+  });
+});

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -1,10 +1,20 @@
 'use strict';
 var assert = require('assert');
 var rule = require('../lib/rules/yo-version');
+var proxyquire = require('proxyquire');
 
 describe('yo version', function () {
+  var latestVersion = {};
+  var rule = proxyquire('../lib/rules/yo-version', {
+    'latest-version': function(name) {
+      return latestVersion;
+    }
+  });
+
   it('pass if it\'s new enough', function (cb) {
-    rule.OLDEST_YO_VERSION = 'v0.0.0';
+    latestVersion.then = function(callback) {
+      callback('1.8.4');
+    };
 
     rule.verify(function (err) {
       assert(!err, err);
@@ -13,7 +23,9 @@ describe('yo version', function () {
   });
 
   it('fail if it\'s too old', function (cb) {
-    rule.OLDEST_YO_VERSION = 'v100.0.0';
+    latestVersion.then = function(callback) {
+      callback('999.999.999');
+    }
 
     rule.verify(function (err) {
       assert(err, err);

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -3,15 +3,19 @@ var assert = require('assert');
 var proxyquire = require('proxyquire');
 
 describe('yo version', function () {
-  var latestVersion = {};
+  var latestVersion = {
+    catch: function () {
+      return latestVersion;
+    }
+  };
   var rule = proxyquire('../lib/rules/yo-version', {
-    'latest-version': function(name) {
+    'latest-version': function () {
       return latestVersion;
     }
   });
 
   it('pass if it\'s new enough', function (cb) {
-    latestVersion.then = function(callback) {
+    latestVersion.then = function (callback) {
       callback('1.8.4');
     };
 
@@ -22,9 +26,9 @@ describe('yo version', function () {
   });
 
   it('fail if it\'s too old', function (cb) {
-    latestVersion.then = function(callback) {
+    latestVersion.then = function (callback) {
       callback('999.999.999');
-    }
+    };
 
     rule.verify(function (err) {
       assert(err, err);


### PR DESCRIPTION
Some releases (like patches) include fixes to bugs.  Its helpful for the user to see that they are running an out-of-date version of yo, if they are.

![image](https://cloud.githubusercontent.com/assets/6251703/12884791/dfd29382-ce1d-11e5-9c8a-c1c68e6cd5d8.png)
