### PR TITLE
Fix .bowerrc and .yo-rc.json error messages

### DIFF
--- a/lib/messages/bowerrc-home-file-exists.twig
+++ b/lib/messages/bowerrc-home-file-exists.twig
@@ -1,5 +1,5 @@
 
-We found a {{ .bowerrc | cyan }} file in your home directory. This can cause
+We found a {{ bowerrc | cyan }} file in your home directory. This can cause
 issues by overriding expected default config. Prefer setting up one `.bowerrc` per
 project.
 

--- a/lib/messages/yo-rc-home-file-exists.twig
+++ b/lib/messages/yo-rc-home-file-exists.twig
@@ -1,5 +1,5 @@
 
-Found a {{ .yo-rc.json | cyan }} file in your home directory. Delete it otherwise
+Found a {{ yorc | cyan }} file in your home directory. Delete it otherwise
 Yeoman will generate everything in your home rather then your project folder.
 
 To delete the file, run: {{ command | magenta }}


### PR DESCRIPTION
This PR fixes #36 which was caused by error messages interpreting the intended text as variable names. This issue can be fixed either by surrounding the text with quotes so that it's interpreted as a string literal, or by using proper variable names. Since the error message rules are already passing variables for these strings, I decided to make use of them.