### PR TITLE
fix pnpm postinstall error

### DIFF
--- a/lib/rules/node-path.js
+++ b/lib/rules/node-path.js
@@ -32,7 +32,7 @@ function fixPath(filepath) {
   try {
     fixedPath = fs.realpathSync(fixedPath);
   } catch (err) {
-    if (err.code !== 'ENOENT') {
+    if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
       throw err;
     }
   }


### PR DESCRIPTION
When using pnpm with rush on a Mac, the yeoman-doctor postinstall step fails. This is due to fixPath() not handling the 'normal' error code ENOTDIR, in addition to ENOENT.

Adding ENOTDIR as an allowed error resolves the problem, while keeping the logical intent of the function unchanged.