### PR TITLE
Update bin-version-check package not to use cross-spaws-async package.

### DIFF
--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -18,7 +18,7 @@ exports.verify = async () => {
     const result = await binVersionCheck('yo', `>=${version}`);
     return result;
   } catch (error) {
-    if (error.name === 'InvalidBinVersion') {
+    if (error.name === 'InvalidBinaryVersion') {
       return errors.oldYoVersion();
     }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^3.2.0",
-		"bin-version-check": "^3.0.0",
+		"bin-version-check": "^4.0.0",
 		"chalk": "^2.3.0",
 		"global-agent": "^2.0.0",
 		"global-tunnel-ng": "^2.5.3",

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -27,4 +27,11 @@ describe('yo version', () => {
     const error = await rule.verify();
     assert(error, error);
   });
+
+  it('fail if it\'s invalid version range', async () => {
+    latestVersion = {...latestVersion, then: cb => cb('-1')};
+
+    const error = await rule.verify();
+    assert(error, error);
+  });
 });


### PR DESCRIPTION
When installing yeoman using npm, I get the following warning:

```
npm WARN deprecated cross-spawn-async@2.2.5: cross-spawn no longer requires a build toolchain, use it instead
```

This is due to the old `bin-version-check` package, which is doctor's dependent library, so it can be resolved by using a newer version.

How about it?

```
$ npm install -g yo
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated cross-spawn-async@2.2.5: cross-spawn no longer requires a build toolchain, use it instead
<User home directory>/.nodebrew/node/v12.16.2/bin/yo -> <User home directory>/.nodebrew/node/v12.16.2/lib/node_modules/yo/lib/cli.js
<User home directory>/.nodebrew/node/v12.16.2/bin/yo-complete -> <User home directory>/.nodebrew/node/v12.16.2/lib/node_modules/yo/lib/completion/index.js

> core-js@3.6.5 postinstall <User home directory>/.nodebrew/node/v12.16.2/lib/node_modules/yo/node_modules/core-js
> node -e "try{require('./postinstall')}catch(e){}"

Thank you for using core-js ( https://github.com/zloirock/core-js ) for polyfilling JavaScript standard library!

The project needs your help! Please consider supporting of core-js on Open Collective or Patreon: 
> https://opencollective.com/core-js 
> https://www.patreon.com/zloirock 

Also, the author of core-js ( https://github.com/zloirock ) is looking for a good job -)


> ejs@2.7.4 postinstall <User home directory>/.nodebrew/node/v12.16.2/lib/node_modules/yo/node_modules/ejs
> node ./postinstall.js

Thank you for installing EJS: built with the Jake JavaScript build tool (https://jakejs.com/)


> spawn-sync@1.0.15 postinstall <User home directory>/.nodebrew/node/v12.16.2/lib/node_modules/yo/node_modules/spawn-sync
> node postinstall


> yo@3.1.1 postinstall <User home directory>/.nodebrew/node/v12.16.2/lib/node_modules/yo
> yodoctor


Yeoman Doctor
Running sanity checks on your system

✔ No .bowerrc file in home directory
✔ Global configuration file is valid
✔ NODE_PATH matches the npm root
✔ No .yo-rc.json file in home directory
✔ Node.js version
✔ npm version
✔ yo version

Everything looks all right!
+ yo@3.1.1
added 684 packages from 392 contributors in 21.82s
```