### PR TITLE
Update bin-version-check package (#53)

### DIFF
--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -18,7 +18,7 @@ exports.verify = async () => {
     const result = await binVersionCheck('yo', `>=${version}`);
     return result;
   } catch (error) {
-    if (error.name === 'InvalidBinVersion') {
+    if (error.name === 'InvalidBinaryVersion') {
       return errors.oldYoVersion();
     }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^3.2.0",
-		"bin-version-check": "^3.0.0",
+		"bin-version-check": "^4.0.0",
 		"chalk": "^2.3.0",
 		"global-agent": "^2.0.0",
 		"global-tunnel-ng": "^2.5.3",

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -27,4 +27,11 @@ describe('yo version', () => {
     const error = await rule.verify();
     assert(error, error);
   });
+
+  it('fail if it\'s invalid version range', async () => {
+    latestVersion = {...latestVersion, then: cb => cb('-1')};
+
+    const error = await rule.verify();
+    assert(error, error);
+  });
 });


### PR DESCRIPTION
Reviving pr #53 after being open for over a year with no activity since, and then (presumably) closed due to inactivity.

The original issue (#49) along with the pr stated that:

>Installing software using the latest version of yeoman-doctor gives deprecation warnings:
>
>     npm WARN deprecated cross-spawn-async@2.2.5: cross-spawn no longer requires a build toolchain, use it instead
>
>The package was updated in an upstream dependency, execa, which eventually was updated in bin-version-check version 4.0.0:

Right before the pr became inactive the @LitoMore had approved the pr and pinged @SBoudrias (presumably to merge the pr).