### PR TITLE
chore: update bin-version-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^3.2.0",
-		"bin-version-check": "^4.0.0",
+		"bin-version-check": "^5.0.0",
 		"chalk": "^2.3.0",
 		"global-agent": "^2.0.0",
 		"latest-version": "^3.1.0",


### PR DESCRIPTION
Needed to fix this vulnerability in yo:
![image](https://user-images.githubusercontent.com/65456722/144923404-8fa1d1c8-a355-474c-bfe8-18170475dfb9.png)