### PR TITLE
update bin-version-check

### DIFF
--- a/lib/bin-version-check.js
+++ b/lib/bin-version-check.js
@@ -1,0 +1,24 @@
+'use strict';
+const semver = require('semver');
+const binaryVersion = require('bin-version');
+const semverTruncate = require('semver-truncate');
+
+module.exports = async (binary, semverRange, options) => {
+  if (typeof binary !== 'string' || typeof semverRange !== 'string') {
+    throw new TypeError('`binary` and `semverRange` arguments required');
+  }
+
+  if (!semver.validRange(semverRange)) {
+    throw new Error('Invalid version range');
+  }
+
+  const version = await binaryVersion(binary, options);
+
+  if (semver.satisfies(semverTruncate(version, 'patch'), semverRange)) {
+    return;
+  }
+
+  const error = new Error(`${binary} ${version} doesn't satisfy the version requirement of ${semverRange}`);
+  error.name = 'InvalidBinaryVersion';
+  throw error;
+};

--- a/lib/rules/npm-version.js
+++ b/lib/rules/npm-version.js
@@ -1,5 +1,5 @@
 'use strict';
-const binVersionCheck = require('bin-version-check');
+const binVersionCheck = require('../bin-version-check');
 const message = require('../message');
 
 exports.OLDEST_NPM_VERSION = '3.3.0';

--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -1,6 +1,6 @@
 'use strict';
 const latestVersion = require('latest-version');
-const binVersionCheck = require('bin-version-check');
+const binVersionCheck = require('../bin-version-check');
 const message = require('../message');
 
 exports.description = 'yo version';

--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^3.2.0",
-		"bin-version-check": "^4.0.0",
+		"bin-version": "^5.0.0",
 		"chalk": "^2.3.0",
 		"global-agent": "^2.0.0",
 		"latest-version": "^3.1.0",
 		"log-symbols": "^2.1.0",
 		"semver": "^5.0.3",
+		"semver-truncate": "^1.1.2",
 		"twig": "^1.10.5",
 		"user-home": "^2.0.0"
 	},


### PR DESCRIPTION
I faced also with the same issue in connection with the vulnerable semver version (#62). I gave a try to internalize a working version of bin-version-check and that way to upgrade bin-version which is incorporating a safe version (3.1.4) of semver.