### PR TITLE
feat!: switch to ESM and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,7 @@ jobs:
       # TODO: Include windows-latest when https://github.com/yeoman/doctor/issues/69 is resolved
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [12, 13, 14, 15, 16, 17, 18]
-        # Avoid Error: Unable to find Node versions for platform darwin and architecture arm64: 
-        exclude:
-          - os: macos-latest
-            node: 12
-          - os: macos-latest
-            node: 13
-          - os: macos-latest
-            node: 14
-          - os: macos-latest
-            node: 15
+        node: [18, 20, 22, 23]
 
     steps:
       - name: Checkout repository

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"yo-doctor": "lib/cli.js"
 	},
 	"engines": {
-		"node": ">=12.10.0"
+		"node": ">=18.20.0"
 	},
 	"scripts": {
 		"test": "xo && mocha test/** -R spec"
@@ -31,20 +31,20 @@
 		"check"
 	],
 	"dependencies": {
-		"ansi-styles": "^3.2.0",
-		"bin-version-check": "^4.0.0",
-		"chalk": "^2.3.0",
-		"global-agent": "^2.0.0",
-		"latest-version": "^3.1.0",
-		"log-symbols": "^2.1.0",
-		"semver": "^5.0.3",
-		"twig": "^1.10.5"
+		"ansi-styles": "^6.2.1",
+		"bin-version-check": "^6.0.0",
+		"chalk": "^5.4.1",
+		"global-agent": "^3.0.0",
+		"latest-version": "^9.0.0",
+		"log-symbols": "^7.0.0",
+		"semver": "^7.7.1",
+		"twig": "^1.17.1"
 	},
 	"devDependencies": {
-		"mocha": "^4.1.0",
-		"proxyquire": "^1.7.9",
-		"sinon": "^4.1.3",
-		"xo": "^0.24.0"
+		"mocha": "^11.1.0",
+		"proxyquire": "^2.1.3",
+		"sinon": "^19.0.4",
+		"xo": "^0.60.0"
 	},
 	"xo": {
 		"space": true,

--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
 			"unicorn/prefer-module": "off",
 			"unicorn/prefer-node-protocol": "off"
 		}
-	}
+	},
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"yo-doctor": "lib/cli.js"
 	},
 	"engines": {
-		"node": ">=18.20.0"
+		"node": "^20.19.0 || >=22.12.0"
 	},
 	"scripts": {
     "lint": "xo",


### PR DESCRIPTION
Draft PR just testing things out - not intended or ready for review yet.

## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [x] Other, please explain: internal overhaul that switches from CJS to ESM

## What changes did you make?

1. Added `"type": "module"` to `package.json`
2. Ran [`ncu -u`](https://www.npmjs.com/package/npm-check-updates) to update all dependencies to latest as of March 2025
    * There have been updates since, but some of them are more breaking (e.g. `xo` moving to 1.x)
4. Bumps Node versions in CI to be ~~>=18 - the LTS majors for the next 5 weeks~~ `^20.19.0 || >=22.12.0` for require(esm)

No actual functionality or logic should be changed. 

## Is there anything you'd like reviewers to focus on?

I normally go for smaller, slower rollouts. But since `doctor` is technically a standalone tool separate from `yo`/Yeoman I thought this'd be a good way to test for breakages from ESM or new package dependencies. I wouldn't be upset if told to reduce scope, though.