### PR TITLE
chore: bump xo to v0.60.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,25 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint
+
+  test:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -21,7 +39,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         node: [12, 13, 14, 15, 16, 17, 18]
-        # Avoid Error: Unable to find Node versions for platform darwin and architecture arm64: 
+        # Avoid Error: Unable to find Node versions for platform darwin and architecture arm64:
         exclude:
           - os: macos-latest
             node: 12

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-require('.')();
+require('./index.js')();
 
 // Override http networking to go through a proxy if one is configured.
 require('global-agent').bootstrap();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,32 +1,36 @@
 'use strict';
 const chalk = require('chalk');
 const symbols = require('log-symbols');
-const rules = require('./rules');
+const rules = require('./rules/index.js');
 
-module.exports = function () {
-  let errCount = 0;
+function doctor() {
+  let errorCount = 0;
 
   console.log('\n' + chalk.underline.blue('Yeoman Doctor'));
   console.log('Running sanity checks on your system\n');
 
   (async () => {
     await Promise.all(
-      Object.values(rules).map(rule => {
-        return rule.verify().then(error => {
-          console.log((error ? symbols.error : symbols.success) + ' ' + rule.description);
+      Object.values(rules).map(rule =>
+        rule.verify().then(error => {
+          console.log(
+            (error ? symbols.error : symbols.success) + ' ' + rule.description,
+          );
 
           if (error) {
-            errCount++;
+            errorCount++;
             console.log(error);
           }
-        });
-      })
+        }),
+      ),
     );
 
-    if (errCount === 0) {
+    if (errorCount === 0) {
       console.log(chalk.green('\nEverything looks all right!'));
     } else {
       console.log(chalk.red('\nFound potential issues on your machine :('));
     }
   })();
-};
+}
+
+module.exports = doctor;

--- a/lib/rules/bowerrc-home.js
+++ b/lib/rules/bowerrc-home.js
@@ -1,8 +1,9 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const process = require('process');
 const os = require('os');
-const message = require('../message');
+const message = require('../message.js');
 
 exports.description = 'No .bowerrc file in home directory';
 
@@ -11,9 +12,9 @@ const errors = {
     const rm = process.platform === 'win32' ? 'del' : 'rm';
     return message.get('bowerrc-home-file-exists', {
       bowerrc: '.bowerrc',
-      command: rm + ' ~/.bowerrc'
+      command: rm + ' ~/.bowerrc',
     });
-  }
+  },
 };
 exports.errors = errors;
 

--- a/lib/rules/global-config.js
+++ b/lib/rules/global-config.js
@@ -2,23 +2,23 @@
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const message = require('../message');
+const message = require('../message.js');
 
 exports.description = 'Global configuration file is valid';
 
 const errors = {
-  syntax(err, configPath) {
+  syntax(error, configPath) {
     return message.get('global-config-syntax', {
-      message: err.message,
-      path: configPath
+      message: error.message,
+      path: configPath,
     });
   },
 
   misc(configPath) {
     return message.get('global-config-misc', {
-      path: configPath
+      path: configPath,
     });
-  }
+  },
 };
 exports.errors = errors;
 

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,8 +1,8 @@
 'use strict';
-exports['bowerrc-home'] = require('./bowerrc-home');
-exports['global-config'] = require('./global-config');
-exports['node-path'] = require('./node-path');
-exports['yo-rc-home'] = require('./yo-rc-home');
-exports['node-version'] = require('./node-version');
-exports['npm-version'] = require('./npm-version');
-exports['yo-version'] = require('./yo-version');
+exports['bowerrc-home'] = require('./bowerrc-home.js');
+exports['global-config'] = require('./global-config.js');
+exports['node-path'] = require('./node-path.js');
+exports['yo-rc-home'] = require('./yo-rc-home.js');
+exports['node-version'] = require('./node-version.js');
+exports['npm-version'] = require('./npm-version.js');
+exports['yo-version'] = require('./yo-version.js');

--- a/lib/rules/node-path.js
+++ b/lib/rules/node-path.js
@@ -1,8 +1,9 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const process = require('process');
 const childProcess = require('child_process');
-const message = require('../message');
+const message = require('../message.js');
 
 exports.description = 'NODE_PATH matches the npm root';
 
@@ -12,17 +13,17 @@ const errors = {
   },
 
   pathMismatch(npmRoot) {
-    let msgPath = 'node-path-path-mismatch';
+    let messagePath = 'node-path-path-mismatch';
 
     if (process.platform === 'win32') {
-      msgPath += '-windows';
+      messagePath += '-windows';
     }
 
-    return message.get(msgPath, {
+    return message.get(messagePath, {
       path: process.env.NODE_PATH,
-      npmroot: npmRoot
+      npmroot: npmRoot,
     });
-  }
+  },
 };
 exports.errors = errors;
 
@@ -45,18 +46,18 @@ exports.verify = async () => {
     return null;
   }
 
-  const nodePaths = (process.env.NODE_PATH || '').split(path.delimiter).map(fixPath);
+  const nodePaths = (process.env.NODE_PATH || '').split(path.delimiter).map(segment => fixPath(segment));
 
   try {
     const stdout = childProcess.execSync('npm -g root --silent');
     const npmRoot = fixPath(stdout);
 
-    if (nodePaths.indexOf(npmRoot) < 0) {
+    if (!nodePaths.includes(npmRoot)) {
       return errors.pathMismatch(npmRoot);
     }
 
     return null;
-  } catch (error) {
+  } catch {
     return errors.npmFailure();
   }
 };

--- a/lib/rules/node-version.js
+++ b/lib/rules/node-version.js
@@ -1,6 +1,7 @@
 'use strict';
+const process = require('process');
 const semver = require('semver');
-const message = require('../message');
+const message = require('../message.js');
 
 const OLDEST_NODE_VERSION = '4.2.0';
 
@@ -9,10 +10,8 @@ exports.description = 'Node.js version';
 const errors = {
   oldNodeVersion() {
     return message.get('node-version');
-  }
+  },
 };
 exports.errors = errors;
 
-exports.verify = async () => {
-  return semver.lt(process.version, OLDEST_NODE_VERSION) ? errors.oldNodeVersion() : null;
-};
+exports.verify = async () => semver.lt(process.version, OLDEST_NODE_VERSION) ? errors.oldNodeVersion() : null;

--- a/lib/rules/npm-version.js
+++ b/lib/rules/npm-version.js
@@ -1,6 +1,7 @@
 'use strict';
+const process = require('process');
 const binVersionCheck = require('bin-version-check');
-const message = require('../message');
+const message = require('../message.js');
 
 exports.OLDEST_NPM_VERSION = '3.3.0';
 exports.description = 'npm version';
@@ -8,9 +9,9 @@ exports.description = 'npm version';
 const errors = {
   oldNpmVersion() {
     return message.get('npm-version', {
-      isWin: process.platform === 'win32'
+      isWin: process.platform === 'win32',
     });
-  }
+  },
 };
 exports.errors = errors;
 
@@ -18,7 +19,7 @@ exports.verify = async () => {
   try {
     const result = await binVersionCheck('npm', `>=${exports.OLDEST_NPM_VERSION}`);
     return result;
-  } catch (error) {
+  } catch {
     return errors.oldNpmVersion();
   }
 };

--- a/lib/rules/yo-rc-home.js
+++ b/lib/rules/yo-rc-home.js
@@ -1,8 +1,9 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const process = require('process');
 const os = require('os');
-const message = require('../message');
+const message = require('../message.js');
 
 exports.description = 'No .yo-rc.json file in home directory';
 
@@ -11,9 +12,9 @@ const errors = {
     const rm = process.platform === 'win32' ? 'del' : 'rm';
     return message.get('yo-rc-home-file-exists', {
       yorc: '.yo-rc.json',
-      command: rm + ' ~/.yo-rc.json'
+      command: rm + ' ~/.yo-rc.json',
     });
-  }
+  },
 };
 exports.errors = errors;
 

--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -1,14 +1,14 @@
 'use strict';
 const latestVersion = require('latest-version');
 const binVersionCheck = require('bin-version-check');
-const message = require('../message');
+const message = require('../message.js');
 
 exports.description = 'yo version';
 
 const errors = {
   oldYoVersion() {
     return message.get('yo-version-out-of-date', {});
-  }
+  },
 };
 exports.errors = errors;
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"mocha": "^4.1.0",
 		"proxyquire": "^1.7.9",
 		"sinon": "^4.1.3",
-		"xo": "^0.24.0"
+		"xo": "^0.60.0"
 	},
 	"xo": {
 		"space": true,
@@ -53,7 +53,9 @@
 			"mocha"
 		],
 		"rules": {
-			"node/no-deprecated-api": "off"
+			"node/no-deprecated-api": "off",
+			"unicorn/prefer-module": "off",
+			"unicorn/prefer-node-protocol": "off"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"node": ">=12.10.0"
 	},
 	"scripts": {
-		"test": "xo && mocha test/** -R spec"
+    "lint": "xo",
+		"test": "mocha test/** -R spec"
 	},
 	"files": [
 		"lib"

--- a/test/rule-bowerrc-home.js
+++ b/test/rule-bowerrc-home.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const assert = require('assert');
 const sinon = require('sinon');
-const rule = require('../lib/rules/bowerrc-home');
+const rule = require('../lib/rules/bowerrc-home.js');
 
 describe('global .bowerrc rule', () => {
   beforeEach(function () {

--- a/test/rule-global-config.js
+++ b/test/rule-global-config.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const sinon = require('sinon');
-const rule = require('../lib/rules/global-config');
+const rule = require('../lib/rules/global-config.js');
 
 // Setting the message paths & files before fs is stubbed
 const messageSyntaxPath = path.join(__dirname, '../lib/messages', 'global-config-syntax.twig');

--- a/test/rule-node-path.js
+++ b/test/rule-node-path.js
@@ -2,8 +2,9 @@
 const assert = require('assert');
 const path = require('path');
 const childProcess = require('child_process');
+const process = require('process');
 const sinon = require('sinon');
-const rule = require('../lib/rules/node-path');
+const rule = require('../lib/rules/node-path.js');
 
 describe('NODE_PATH rule', () => {
   beforeEach(function () {
@@ -30,7 +31,7 @@ describe('NODE_PATH rule', () => {
   });
 
   it('fail if the npm call throw', async function () {
-    this.sandbox.stub(childProcess, 'execSync').returns(new Error());
+    this.sandbox.stub(childProcess, 'execSync').returns(new Error('Child Process failure'));
     process.env.NODE_PATH = 'some-path';
     const error = await rule.verify();
     assert.equal(error, rule.errors.npmFailure());

--- a/test/rule-node-version.js
+++ b/test/rule-node-version.js
@@ -1,6 +1,7 @@
 'use strict';
 const assert = require('assert');
-const rule = require('../lib/rules/node-version');
+const process = require('process');
+const rule = require('../lib/rules/node-version.js');
 
 let _processVersion;
 

--- a/test/rule-npm-version.js
+++ b/test/rule-npm-version.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const rule = require('../lib/rules/npm-version');
+const rule = require('../lib/rules/npm-version.js');
 
 describe('npm version', () => {
   it('pass if it\'s new enough', async () => {

--- a/test/rule-yo-rc-home.js
+++ b/test/rule-yo-rc-home.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const assert = require('assert');
 const sinon = require('sinon');
-const rule = require('../lib/rules/yo-rc-home');
+const rule = require('../lib/rules/yo-rc-home.js');
 
 describe('global .yo-rc.json rule', () => {
   beforeEach(function () {

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-thenable */
 'use strict';
 const assert = require('assert');
 const proxyquire = require('proxyquire');
@@ -6,30 +7,30 @@ describe('yo version', () => {
   let latestVersion = {
     catch() {
       return latestVersion;
-    }
+    },
   };
-  const rule = proxyquire('../lib/rules/yo-version', {
+  const rule = proxyquire('../lib/rules/yo-version.js', {
     'latest-version'() {
       return latestVersion;
-    }
+    },
   });
 
   it('pass if it\'s new enough', async () => {
-    latestVersion = {...latestVersion, then: cb => cb('1.8.4')};
+    latestVersion = {...latestVersion, then: callback => callback('1.8.4')};
 
     const error = await rule.verify();
     assert(!error, error);
   });
 
   it('fail if it\'s too old', async () => {
-    latestVersion = {...latestVersion, then: cb => cb('999.999.999')};
+    latestVersion = {...latestVersion, then: callback => callback('999.999.999')};
 
     const error = await rule.verify();
     assert(error, error);
   });
 
   it('fail if it\'s invalid version range', async () => {
-    latestVersion = {...latestVersion, then: cb => cb('-1')};
+    latestVersion = {...latestVersion, then: callback => callback('-1')};
 
     const error = await rule.verify();
     assert(error, error);


### PR DESCRIPTION
As with https://github.com/yeoman/yo/pull/876, bumps to the latest [`xo`](https://www.npmjs.com/package/xo). This includes fixing newly reported complaints, most of which were one of:

* [`comma/dangle`](https://eslint.org/docs/latest/rules/comma-dangle)
* [`import/extensions`](https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/extensions.md)
* [`n/prefer-global/process`](https://github.com/eslint-community/eslint-plugin-n/blob/002ac9cbc57272b9b3d28fb6aaea32dc8235bfc4/docs/rules/prefer-global/process.md)
* [`unicorn/prevent-abbreviations`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/f862e0c07a3055b0ce6a7f7860fb80c64e5a0d19/docs/rules/prevent-abbreviations.md)

Keeps the following rules disabled in `package.json`'s `"xo"` settings:

* [`unicorn/prefer-module`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v56.0.1/docs/rules/prefer-module.md): since this is still a CJS package
* [`unicorn/prefer-node-protocol`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v56.0.1/docs/rules/prefer-node-protocol.md): this package still supports 12.10.0; `node:*` modules were only backported to 12.20.0

This should at least partially unblock #75.