### PR TITLE
chore: only lint in CI on latest matrix.node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,25 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint
+
+  test:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -21,7 +39,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         node: [12, 13, 14, 15, 16, 17, 18]
-        # Avoid Error: Unable to find Node versions for platform darwin and architecture arm64: 
+        # Avoid Error: Unable to find Node versions for platform darwin and architecture arm64:
         exclude:
           - os: macos-latest
             node: 12

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"node": ">=12.10.0"
 	},
 	"scripts": {
-		"test": "xo && mocha test/** -R spec"
+    "lint": "xo",
+		"test": "mocha test/** -R spec"
 	},
 	"files": [
 		"lib"


### PR DESCRIPTION
## Purpose of this pull request? 

- [ ] Documentation update
- [ ] Bug fix 
- [ ] Enhancement
- [x] Other, please explain: CI enhancement

## What changes did you make?

Removes linting from the `test` script so that it can be run just once in CI. There's no need to run `xo` on various Node.js versions. Linting behavior is stable between them.

## Is there anything you'd like reviewers to focus on?

Split out of #76, which should at least partially unblock #75.