### PR TITLE
Move to ESM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm install
@@ -33,22 +33,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      # TODO: Include Node@22 and Node@23 when https://github.com/yeoman/yo/issues/842 is resolved
-      # TODO: Include Node@19, Node@20, Node@21 when https://github.com/yeoman/doctor/issues/67 is resolved
-      # TODO: Include windows-latest when https://github.com/yeoman/doctor/issues/69 is resolved
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        node: [12, 13, 14, 15, 16, 17, 18]
-        # Avoid Error: Unable to find Node versions for platform darwin and architecture arm64:
-        exclude:
-          - os: macos-latest
-            node: 12
-          - os: macos-latest
-            node: 13
-          - os: macos-latest
-            node: 14
-          - os: macos-latest
-            node: 15
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [20, 22, 23, 24]
 
     steps:
       - name: Checkout repository

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-'use strict';
-require('./index.js')();
+import globalAgent from 'global-agent';
+import app from './index.js';
+
+app();
 
 // Override http networking to go through a proxy if one is configured.
-require('global-agent').bootstrap();
+globalAgent.bootstrap();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,29 +1,24 @@
-'use strict';
-const chalk = require('chalk');
-const symbols = require('log-symbols');
-const rules = require('./rules/index.js');
+import chalk from 'chalk';
+import symbols from 'log-symbols';
+import rules from './rules/index.js';
 
-function doctor() {
+export default function doctor() {
   let errorCount = 0;
 
   console.log('\n' + chalk.underline.blue('Yeoman Doctor'));
   console.log('Running sanity checks on your system\n');
 
   (async () => {
-    await Promise.all(
-      Object.values(rules).map(rule =>
-        rule.verify().then(error => {
-          console.log(
-            (error ? symbols.error : symbols.success) + ' ' + rule.description,
-          );
+    await Promise.all(Object.values(rules).map(rule =>
+      // eslint-disable-next-line promise/prefer-await-to-then
+      rule.verify().then(error => {
+        console.log((error ? symbols.error : symbols.success) + ' ' + rule.description);
 
-          if (error) {
-            errorCount++;
-            console.log(error);
-          }
-        }),
-      ),
-    );
+        if (error) {
+          errorCount++;
+          console.log(error);
+        }
+      })));
 
     if (errorCount === 0) {
       console.log(chalk.green('\nEverything looks all right!'));
@@ -32,5 +27,3 @@ function doctor() {
     }
   })();
 }
-
-module.exports = doctor;

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,16 +1,18 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
-const chalk = require('chalk');
-const ansiStyles = require('ansi-styles');
-const Twig = require('twig');
+import path from 'node:path';
+import fs from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import chalk from 'chalk';
+import ansiStyles from 'ansi-styles';
+import Twig from 'twig';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Add Chalk to Twig
 for (const style of Object.keys(ansiStyles)) {
   Twig.extendFilter(style, input => chalk[style](input));
 }
 
-exports.get = (message, data) => {
+export default function getMessage(message, data) {
   const fileTemplate = fs.readFileSync(path.join(__dirname, 'messages', `${message}.twig`), 'utf8');
   return Twig.twig({data: fileTemplate}).render(data);
-};
+}

--- a/lib/rules/bowerrc-home.js
+++ b/lib/rules/bowerrc-home.js
@@ -1,26 +1,25 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
-const process = require('process');
-const os = require('os');
-const message = require('../message.js');
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import os from 'node:os';
+import getMessage from '../message.js';
 
-exports.description = 'No .bowerrc file in home directory';
-
-const errors = {
-  fileExists() {
-    const rm = process.platform === 'win32' ? 'del' : 'rm';
-    return message.get('bowerrc-home-file-exists', {
-      bowerrc: '.bowerrc',
-      command: rm + ' ~/.bowerrc',
-    });
+const rule = {
+  description: 'No .bowerrc file in home directory',
+  errors: {
+    fileExists() {
+      const rm = process.platform === 'win32' ? 'del' : 'rm';
+      return getMessage('bowerrc-home-file-exists', {
+        bowerrc: '.bowerrc',
+        command: rm + ' ~/.bowerrc',
+      });
+    },
+  },
+  bowerrcPath: path.join(os.homedir(), '.bowerrc'),
+  async verify() {
+    const exists = fs.existsSync(this.bowerrcPath);
+    return exists ? this.errors.fileExists() : null;
   },
 };
-exports.errors = errors;
 
-exports.bowerrcPath = path.join(os.homedir(), '.bowerrc');
-
-exports.verify = async () => {
-  const exists = fs.existsSync(this.bowerrcPath);
-  return exists ? errors.fileExists() : null;
-};
+export default rule;

--- a/lib/rules/global-config.js
+++ b/lib/rules/global-config.js
@@ -1,43 +1,42 @@
-'use strict';
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
-const message = require('../message.js');
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import getMessage from '../message.js';
 
-exports.description = 'Global configuration file is valid';
+const rule = {
+  description: 'Global configuration file is valid',
+  errors: {
+    syntax(error, configPath) {
+      return getMessage('global-config-syntax', {
+        message: error.message,
+        path: configPath,
+      });
+    },
 
-const errors = {
-  syntax(error, configPath) {
-    return message.get('global-config-syntax', {
-      message: error.message,
-      path: configPath,
-    });
+    misc(configPath) {
+      return getMessage('global-config-misc', {
+        path: configPath,
+      });
+    },
   },
-
-  misc(configPath) {
-    return message.get('global-config-misc', {
-      path: configPath,
-    });
-  },
-};
-exports.errors = errors;
-
-exports.configPath = path.join(os.homedir(), '.yo-rc-global.json');
-
-exports.verify = async () => {
-  if (!fs.existsSync(this.configPath)) {
-    return null;
-  }
-
-  try {
-    JSON.parse(fs.readFileSync(this.configPath, 'utf8'));
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      return errors.syntax(error, this.configPath);
+  configPath: path.join(os.homedir(), '.yo-rc-global.json'),
+  async verify() {
+    if (!fs.existsSync(this.configPath)) {
+      return null;
     }
 
-    return errors.misc(this.configPath);
-  }
+    try {
+      JSON.parse(fs.readFileSync(this.configPath, 'utf8'));
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return this.errors.syntax(error, this.configPath);
+      }
 
-  return null;
+      return this.errors.misc(this.configPath);
+    }
+
+    return null;
+  },
 };
+
+export default rule;

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,8 +1,13 @@
-'use strict';
-exports['bowerrc-home'] = require('./bowerrc-home.js');
-exports['global-config'] = require('./global-config.js');
-exports['node-path'] = require('./node-path.js');
-exports['yo-rc-home'] = require('./yo-rc-home.js');
-exports['node-version'] = require('./node-version.js');
-exports['npm-version'] = require('./npm-version.js');
-exports['yo-version'] = require('./yo-version.js');
+import bowerrcHome from './bowerrc-home.js';
+import globalConfig from './global-config.js';
+import nodeCath from './node-path.js';
+import yoRcHome from './yo-rc-home.js';
+import nodeVersion from './node-version.js';
+import npmVersion from './npm-version.js';
+import yoVersion from './yo-version.js';
+
+const rules = {
+  bowerrcHome, globalConfig, nodeCath, yoRcHome, nodeVersion, npmVersion, yoVersion,
+};
+
+export default rules;

--- a/lib/rules/node-path.js
+++ b/lib/rules/node-path.js
@@ -1,31 +1,8 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
-const process = require('process');
-const childProcess = require('child_process');
-const message = require('../message.js');
-
-exports.description = 'NODE_PATH matches the npm root';
-
-const errors = {
-  npmFailure() {
-    return message.get('node-path-npm-failure', {});
-  },
-
-  pathMismatch(npmRoot) {
-    let messagePath = 'node-path-path-mismatch';
-
-    if (process.platform === 'win32') {
-      messagePath += '-windows';
-    }
-
-    return message.get(messagePath, {
-      path: process.env.NODE_PATH,
-      npmroot: npmRoot,
-    });
-  },
-};
-exports.errors = errors;
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import childProcess from 'node:child_process';
+import getMessage from '../message.js';
 
 function fixPath(filepath) {
   let fixedPath = path.resolve(path.normalize(filepath.trim()));
@@ -41,23 +18,45 @@ function fixPath(filepath) {
   return fixedPath;
 }
 
-exports.verify = async () => {
-  if (process.env.NODE_PATH === undefined) {
-    return null;
-  }
+const rule = {
+  description: 'NODE_PATH matches the npm root',
+  errors: {
+    npmFailure() {
+      return getMessage('node-path-npm-failure', {});
+    },
+    pathMismatch(npmRoot) {
+      let messagePath = 'node-path-path-mismatch';
 
-  const nodePaths = (process.env.NODE_PATH || '').split(path.delimiter).map(segment => fixPath(segment));
+      if (process.platform === 'win32') {
+        messagePath += '-windows';
+      }
 
-  try {
-    const stdout = childProcess.execSync('npm -g root --silent');
-    const npmRoot = fixPath(stdout);
-
-    if (!nodePaths.includes(npmRoot)) {
-      return errors.pathMismatch(npmRoot);
+      return getMessage(messagePath, {
+        path: process.env.NODE_PATH,
+        npmroot: npmRoot,
+      });
+    },
+  },
+  async verify() {
+    if (process.env.NODE_PATH === undefined) {
+      return null;
     }
 
-    return null;
-  } catch {
-    return errors.npmFailure();
-  }
+    const nodePaths = (process.env.NODE_PATH || '').split(path.delimiter).map(segment => fixPath(segment));
+
+    try {
+      const stdout = childProcess.execSync('npm -g root --silent');
+      const npmRoot = fixPath(stdout);
+
+      if (!nodePaths.includes(npmRoot)) {
+        return this.errors.pathMismatch(npmRoot);
+      }
+
+      return null;
+    } catch {
+      return this.errors.npmFailure();
+    }
+  },
 };
+
+export default rule;

--- a/lib/rules/node-version.js
+++ b/lib/rules/node-version.js
@@ -1,17 +1,18 @@
-'use strict';
-const process = require('process');
-const semver = require('semver');
-const message = require('../message.js');
+import process from 'node:process';
+import semver from 'semver';
+import getMessage from '../message.js';
 
-const OLDEST_NODE_VERSION = '4.2.0';
-
-exports.description = 'Node.js version';
-
-const errors = {
-  oldNodeVersion() {
-    return message.get('node-version');
+const rule = {
+  OLDEST_NODE_VERSION: '4.2.0',
+  description: 'Node.js version',
+  errors: {
+    oldNodeVersion() {
+      return getMessage('node-version');
+    },
+  },
+  async verify() {
+    return semver.lt(process.version, this.OLDEST_NODE_VERSION) ? this.errors.oldNodeVersion() : null;
   },
 };
-exports.errors = errors;
 
-exports.verify = async () => semver.lt(process.version, OLDEST_NODE_VERSION) ? errors.oldNodeVersion() : null;
+export default rule;

--- a/lib/rules/npm-version.js
+++ b/lib/rules/npm-version.js
@@ -1,25 +1,25 @@
-'use strict';
-const process = require('process');
-const binVersionCheck = require('bin-version-check');
-const message = require('../message.js');
+import process from 'node:process';
+import binaryVersionCheck from 'binary-version-check';
+import getMessage from '../message.js';
 
-exports.OLDEST_NPM_VERSION = '3.3.0';
-exports.description = 'npm version';
-
-const errors = {
-  oldNpmVersion() {
-    return message.get('npm-version', {
-      isWin: process.platform === 'win32',
-    });
+const rule = {
+  OLDEST_NPM_VERSION: '3.3.0',
+  description: 'npm version',
+  errors: {
+    oldNpmVersion() {
+      return getMessage('npm-version', {
+        isWin: process.platform === 'win32',
+      });
+    },
+  },
+  async verify() {
+    try {
+      const result = await binaryVersionCheck('npm', `>=${this.OLDEST_NPM_VERSION}`);
+      return result;
+    } catch {
+      return this.errors.oldNpmVersion();
+    }
   },
 };
-exports.errors = errors;
 
-exports.verify = async () => {
-  try {
-    const result = await binVersionCheck('npm', `>=${exports.OLDEST_NPM_VERSION}`);
-    return result;
-  } catch {
-    return errors.oldNpmVersion();
-  }
-};
+export default rule;

--- a/lib/rules/yo-rc-home.js
+++ b/lib/rules/yo-rc-home.js
@@ -1,26 +1,25 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
-const process = require('process');
-const os = require('os');
-const message = require('../message.js');
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import os from 'node:os';
+import getMessage from '../message.js';
 
-exports.description = 'No .yo-rc.json file in home directory';
-
-const errors = {
-  fileExists() {
-    const rm = process.platform === 'win32' ? 'del' : 'rm';
-    return message.get('yo-rc-home-file-exists', {
-      yorc: '.yo-rc.json',
-      command: rm + ' ~/.yo-rc.json',
-    });
+const rule = {
+  description: 'No .yo-rc.json file in home directory',
+  errors: {
+    fileExists() {
+      const rm = process.platform === 'win32' ? 'del' : 'rm';
+      return getMessage('yo-rc-home-file-exists', {
+        yorc: '.yo-rc.json',
+        command: rm + ' ~/.yo-rc.json',
+      });
+    },
+  },
+  yorcPath: path.join(os.homedir(), '.yo-rc.json'),
+  async verify() {
+    const exists = fs.existsSync(this.yorcPath);
+    return exists ? this.errors.fileExists() : null;
   },
 };
-exports.errors = errors;
 
-exports.yorcPath = path.join(os.homedir(), '.yo-rc.json');
-
-exports.verify = async () => {
-  const exists = fs.existsSync(this.yorcPath);
-  return exists ? errors.fileExists() : null;
-};
+export default rule;

--- a/lib/rules/yo-version.js
+++ b/lib/rules/yo-version.js
@@ -1,28 +1,29 @@
-'use strict';
-const latestVersion = require('latest-version');
-const binVersionCheck = require('bin-version-check');
-const message = require('../message.js');
+import latestVersion from 'latest-version';
+import binaryVersionCheck from 'binary-version-check';
+import getMessage from '../message.js';
 
-exports.description = 'yo version';
+const rule = {
+  latestVersion,
+  description: 'yo version',
+  errors: {
+    oldYoVersion() {
+      return getMessage('yo-version-out-of-date', {});
+    },
+  },
+  async verify() {
+    try {
+      const version = await this.latestVersion('yo');
+      const result = await binaryVersionCheck('yo', `>=${version}`);
+      return result;
+    } catch (error) {
+      if (error.name === 'InvalidBinaryVersion') {
+        return this.errors.oldYoVersion();
+      }
 
-const errors = {
-  oldYoVersion() {
-    return message.get('yo-version-out-of-date', {});
+      console.log(error);
+      return error;
+    }
   },
 };
-exports.errors = errors;
 
-exports.verify = async () => {
-  try {
-    const version = await latestVersion('yo');
-    const result = await binVersionCheck('yo', `>=${version}`);
-    return result;
-  } catch (error) {
-    if (error.name === 'InvalidBinaryVersion') {
-      return errors.oldYoVersion();
-    }
-
-    console.log(error);
-    return error;
-  }
-};
+export default rule;

--- a/package.json
+++ b/package.json
@@ -1,62 +1,51 @@
 {
-	"name": "yeoman-doctor",
-	"version": "5.0.0",
-	"description": "Detect potential issues with users system that could prevent Yeoman from working correctly",
-	"license": "BSD-2-Clause",
-	"author": "Yeoman",
-	"repository": "yeoman/doctor",
-	"main": "lib/index.js",
-	"bin": {
-		"yodoctor": "lib/cli.js",
-		"yo-doctor": "lib/cli.js"
-	},
-	"engines": {
-		"node": ">=12.10.0"
-	},
-	"scripts": {
+  "name": "yeoman-doctor",
+  "version": "5.0.0",
+  "description": "Detect potential issues with users system that could prevent Yeoman from working correctly",
+  "license": "BSD-2-Clause",
+  "author": "Yeoman",
+  "repository": "yeoman/doctor",
+  "type": "module",
+  "exports": "./lib/index.js",
+  "bin": {
+    "yodoctor": "./lib/cli.js",
+    "yo-doctor": "./lib/cli.js"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
     "lint": "xo",
-		"test": "mocha test/** -R spec"
-	},
-	"files": [
-		"lib"
-	],
-	"keywords": [
-		"cli-app",
-		"cli",
-		"yeoman",
-		"yo",
-		"doctor",
-		"system",
-		"health",
-		"report",
-		"check"
-	],
-	"dependencies": {
-		"ansi-styles": "^3.2.0",
-		"bin-version-check": "^4.0.0",
-		"chalk": "^2.3.0",
-		"global-agent": "^2.0.0",
-		"latest-version": "^3.1.0",
-		"log-symbols": "^2.1.0",
-		"semver": "^5.0.3",
-		"twig": "^1.10.5"
-	},
-	"devDependencies": {
-		"mocha": "^4.1.0",
-		"proxyquire": "^1.7.9",
-		"sinon": "^4.1.3",
-		"xo": "^0.60.0"
-	},
-	"xo": {
-		"space": true,
-		"envs": [
-			"node",
-			"mocha"
-		],
-		"rules": {
-			"node/no-deprecated-api": "off",
-			"unicorn/prefer-module": "off",
-			"unicorn/prefer-node-protocol": "off"
-		}
-	}
+    "test": "mocha test/** -R spec"
+  },
+  "files": [
+    "lib"
+  ],
+  "keywords": [
+    "cli-app",
+    "cli",
+    "yeoman",
+    "yo",
+    "doctor",
+    "system",
+    "health",
+    "report",
+    "check"
+  ],
+  "dependencies": {
+    "ansi-styles": "^6.2.1",
+    "binary-version-check": "^6.1.0",
+    "chalk": "^5.4.1",
+    "global-agent": "^3.0.0",
+    "latest-version": "^9.0.0",
+    "log-symbols": "^7.0.1",
+    "semver": "^7.7.2",
+    "twig": "^1.17.1"
+  },
+  "devDependencies": {
+    "globals": "^16.3.0",
+    "mocha": "^11.7.1",
+    "sinon": "^21.0.0",
+    "xo": "^1.2.1"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,6 @@
 
 ![](screenshot.png)
 
-
 ## Usage
 
 Use as part of [`yo`](https://github.com/yeoman/yo):
@@ -14,7 +13,6 @@ $ yo doctor
 ```
 
 Can also be run with `yo-doctor` if installed globally.
-
 
 ## License
 

--- a/test/rule-bowerrc-home.js
+++ b/test/rule-bowerrc-home.js
@@ -1,12 +1,11 @@
-'use strict';
-const fs = require('fs');
-const assert = require('assert');
-const sinon = require('sinon');
-const rule = require('../lib/rules/bowerrc-home.js');
+import fs from 'node:fs';
+import assert from 'node:assert';
+import sinon from 'sinon';
+import rule from '../lib/rules/bowerrc-home.js';
 
 describe('global .bowerrc rule', () => {
   beforeEach(function () {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {
@@ -17,7 +16,7 @@ describe('global .bowerrc rule', () => {
     const mock = this.sandbox.mock(fs);
     mock.expects('existsSync').once().withArgs(rule.bowerrcPath).returns(false);
     const error = await rule.verify();
-    assert(!error);
+    assert.ok(!error);
     mock.verify();
   });
 

--- a/test/rule-global-config.js
+++ b/test/rule-global-config.js
@@ -1,9 +1,11 @@
-'use strict';
-const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
-const sinon = require('sinon');
-const rule = require('../lib/rules/global-config.js');
+import assert from 'node:assert';
+import fs from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import path from 'node:path';
+import sinon from 'sinon';
+import rule from '../lib/rules/global-config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Setting the message paths & files before fs is stubbed
 const messageSyntaxPath = path.join(__dirname, '../lib/messages', 'global-config-syntax.twig');
@@ -13,7 +15,7 @@ const messageMiscFile = fs.readFileSync(messageMiscPath, 'utf8');
 
 describe('global config rule', () => {
   beforeEach(function () {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {
@@ -23,14 +25,14 @@ describe('global config rule', () => {
   it('pass if there is no global config', async function () {
     this.sandbox.stub(fs, 'existsSync').returns(false);
     const error = await rule.verify();
-    assert(!error);
+    assert.ok(!error);
   });
 
   it('pass if the config content is valid JSON', async function () {
     this.sandbox.stub(fs, 'existsSync').returns(true);
     this.sandbox.stub(fs, 'readFileSync').returns('{ "foo": 1 }');
     const error = await rule.verify();
-    assert(!error);
+    assert.ok(!error);
   });
 
   it('fails if JSON is invalid', async function () {
@@ -42,7 +44,7 @@ describe('global config rule', () => {
 
     const error = await rule.verify();
     // Assert(error instanceof SyntaxError);
-    assert(error.includes('Unexpected token @'));
+    assert.ok(/Unexpected token '?@/.test(error));
     // Assert.equal(error, rule.errors.syntax(new SyntaxError('Unexpected token @'), rule.configPath));
   });
 

--- a/test/rule-node-path.js
+++ b/test/rule-node-path.js
@@ -1,14 +1,13 @@
-'use strict';
-const assert = require('assert');
-const path = require('path');
-const childProcess = require('child_process');
-const process = require('process');
-const sinon = require('sinon');
-const rule = require('../lib/rules/node-path.js');
+import assert from 'node:assert';
+import path from 'node:path';
+import childProcess from 'node:child_process';
+import process from 'node:process';
+import sinon from 'sinon';
+import rule from '../lib/rules/node-path.js';
 
 describe('NODE_PATH rule', () => {
   beforeEach(function () {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
     this.beforePath = process.env.NODE_PATH;
   });
 
@@ -21,13 +20,13 @@ describe('NODE_PATH rule', () => {
     this.sandbox.stub(childProcess, 'execSync').returns('node-fake-path/foo\n');
     process.env.NODE_PATH = 'node-fake-path/foo';
     const error = await rule.verify();
-    assert(!error);
+    assert.ok(!error);
   });
 
   it('pass if NODE_PATH is undefined', async () => {
     delete process.env.NODE_PATH;
     const error = await rule.verify();
-    assert(!error);
+    assert.ok(!error);
   });
 
   it('fail if the npm call throw', async function () {

--- a/test/rule-node-version.js
+++ b/test/rule-node-version.js
@@ -1,7 +1,6 @@
-'use strict';
-const assert = require('assert');
-const process = require('process');
-const rule = require('../lib/rules/node-version.js');
+import assert from 'node:assert';
+import process from 'process';
+import rule from '../lib/rules/node-version.js';
 
 let _processVersion;
 
@@ -19,13 +18,13 @@ describe('Node.js version', () => {
     process.version = 'v100.0.0';
 
     const error = await rule.verify();
-    assert(!error, error);
+    assert.ok(!error, error);
   });
 
   it('fail if it\'s too old', async () => {
     process.version = 'v0.10.0';
 
     const error = await rule.verify();
-    assert(error, error);
+    assert.ok(error, error);
   });
 });

--- a/test/rule-npm-version.js
+++ b/test/rule-npm-version.js
@@ -1,19 +1,18 @@
-'use strict';
-const assert = require('assert');
-const rule = require('../lib/rules/npm-version.js');
+import assert from 'node:assert';
+import rule from '../lib/rules/npm-version.js';
 
 describe('npm version', () => {
   it('pass if it\'s new enough', async () => {
     rule.OLDEST_NPM_VERSION = 'v1.0.0';
 
     const error = await rule.verify();
-    assert(!error, error);
+    assert.ok(!error, error);
   });
 
   it('fail if it\'s too old', async () => {
     rule.OLDEST_NPM_VERSION = 'v100.0.0';
 
     const error = await rule.verify();
-    assert(error, error);
+    assert.ok(error, error);
   });
 });

--- a/test/rule-yo-rc-home.js
+++ b/test/rule-yo-rc-home.js
@@ -1,12 +1,11 @@
-'use strict';
-const fs = require('fs');
-const assert = require('assert');
-const sinon = require('sinon');
-const rule = require('../lib/rules/yo-rc-home.js');
+import fs from 'node:fs';
+import assert from 'node:assert';
+import sinon from 'sinon';
+import rule from '../lib/rules/yo-rc-home.js';
 
 describe('global .yo-rc.json rule', () => {
   beforeEach(function () {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {
@@ -17,7 +16,7 @@ describe('global .yo-rc.json rule', () => {
     const mock = this.sandbox.mock(fs);
     mock.expects('existsSync').once().withArgs(rule.yorcPath).returns(false);
     const error = await rule.verify();
-    assert(!error);
+    assert.ok(!error);
     mock.verify();
   });
 

--- a/test/rule-yo-version.js
+++ b/test/rule-yo-version.js
@@ -1,38 +1,26 @@
-/* eslint-disable unicorn/no-thenable */
-'use strict';
-const assert = require('assert');
-const proxyquire = require('proxyquire');
+
+import assert from 'node:assert';
+import rule from '../lib/rules/yo-version.js';
 
 describe('yo version', () => {
-  let latestVersion = {
-    catch() {
-      return latestVersion;
-    },
-  };
-  const rule = proxyquire('../lib/rules/yo-version.js', {
-    'latest-version'() {
-      return latestVersion;
-    },
-  });
-
   it('pass if it\'s new enough', async () => {
-    latestVersion = {...latestVersion, then: callback => callback('1.8.4')};
+    rule.latestVersion = () => Promise.resolve('1.8.4');
 
     const error = await rule.verify();
-    assert(!error, error);
+    assert.ok(!error, error);
   });
 
   it('fail if it\'s too old', async () => {
-    latestVersion = {...latestVersion, then: callback => callback('999.999.999')};
+    rule.latestVersion = () => Promise.resolve('999.999.999');
 
     const error = await rule.verify();
-    assert(error, error);
+    assert.ok(error, error);
   });
 
   it('fail if it\'s invalid version range', async () => {
-    latestVersion = {...latestVersion, then: callback => callback('-1')};
+    rule.latestVersion = () => Promise.resolve('-1');
 
     const error = await rule.verify();
-    assert(error, error);
+    assert.ok(error, error);
   });
 });

--- a/xo.config.mjs
+++ b/xo.config.mjs
@@ -1,0 +1,15 @@
+import globals from 'globals';
+
+const xoConfig = [{
+  space: true,
+  languageOptions: {
+    globals: {...globals.node, ...globals.mocha},
+  },
+  rules: {
+    'node/no-deprecated-api': 'off',
+    'unicorn/prefer-module': 'off',
+    'unicorn/prefer-node-protocol': 'off',
+  },
+}];
+
+export default xoConfig;


### PR DESCRIPTION
Part of https://github.com/yeoman/yeoman/issues/1779

- Closes #58
- Fixes #69
- Closes #75 due to its being stale
- Resolves #61
- Fixes #67
- Fixes #68

### Changes

- Bump all dependencies to the latest
- Move to ESM and require Node.js 20
- Dropped `proxyquire` and mock the `latest-version` package with `rule.latestVersion = Promise.resolve(...)` like `test/rule-node-version.js` does
- Update CI test versions to 20, 21, 22, 23, 24 for Linux, macOS, and Windows